### PR TITLE
Support building with plugins

### DIFF
--- a/intellij/Dockerfile
+++ b/intellij/Dockerfile
@@ -1,18 +1,18 @@
 FROM openjdk:8u151-jdk
-ARG IDEA_VERSION=ideaIC-2020.1
+# PLUGIN_IDS is a whitespace separated list of plugins to install
+ARG PLUGIN_IDS
+ARG IDEA_VERSION=2020.1
+ARG IDEA_RELEASE=ideaIC-$IDEA_VERSION
 
 RUN        apt-get update
-RUN        apt-get install -y --no-install-recommends vim
-RUN        apt-get install -y --no-install-recommends wget
-RUN        apt-get install -y --no-install-recommends maven
-RUN        apt-get install -y --no-install-recommends groovy
+RUN        apt-get install -y --no-install-recommends vim wget maven groovy jq
 
 # Clean the APT cache to reduce the size of the container. This step is for
 # hygiene and can be omitted if needed.
 RUN        apt-get clean
 RUN        rm -rf /var/lib/apt/lists/*
 
-RUN        curl https://download-cf.jetbrains.com/idea/${IDEA_VERSION}.tar.gz > /tmp/ideaIC-jdk.tar.gz
+RUN        curl https://download-cf.jetbrains.com/idea/${IDEA_RELEASE}.tar.gz > /tmp/ideaIC-jdk.tar.gz
 
 RUN        mkdir /opt/ide
 RUN        tar -x -C /opt/ide --strip-components=1 -z -f /tmp/ideaIC-jdk.tar.gz
@@ -20,6 +20,16 @@ RUN        ls -lah /opt/ide/
 RUN        rm /tmp/ideaIC-jdk.tar.gz
 
 ENV IDEA_HOME="/opt/ide"
+
+# Set idea plugin property to point to $PLUGINS_DIR and install given plug-ins.
+# The sed trick is based on this https://fabianlee.org/2019/10/05/bash-setting-and-replacing-values-in-a-properties-file-use-sed/
+# See also https://www.jetbrains.com/help/idea/2019.3/tuning-the-ide.html?_ga=2.47595233.757054247.1589007044-1999420621.1579768200#common-platform-properties
+ENV PLUGINS_DIR="/opt/plugins"
+WORKDIR    /opt
+COPY       install-plugin.sh .
+RUN        mkdir -p /opt/plugins && \
+           sed -ir "s_^[#]*\s*idea.plugins.path=.*_idea.plugins.path=${PLUGINS_DIR}_" $IDEA_HOME/bin/idea.properties && \
+           for ID in $PLUGIN_IDS; do ./install-plugin.sh $IDEA_VERSION $ID $PLUGINS_DIR; done
 
 RUN        groupadd -r jetbrains
 RUN        useradd --no-log-init --gid jetbrains --home-dir /home/jetbrains --create-home jetbrains

--- a/intellij/build-scala.sh
+++ b/intellij/build-scala.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+IDEA_VERSION=2020.1
+
+docker build \
+  --build-arg IDEA_VERSION=$IDEA_VERSION \
+  --build-arg PLUGIN_IDS=1347 \
+  --tag intellijidea-scala:$IDEA_VERSION \
+  .

--- a/intellij/install-plugin.sh
+++ b/intellij/install-plugin.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Installs given plugin
+# The plugin is defined by passing the plugin id as an argument.
+# See the scala plugin for example https://plugins.jetbrains.com/plugin/1347-scala
+# The id would be 1347.
+# This script assumes the following arguments
+# - IDEA_VERSION: The idea version, e.g. 2020.1
+# - PLUGIN_ID: The id of the plugin
+# - PLUGINS_DIR: The directory where to install the plugin
+#
+# See https://stackoverflow.com/a/55243388/11140326
+# how to get the plugin URL
+
+IDEA_VERSION=$1
+PLUGIN_ID=$2
+PLUGINS_DIR=$3
+
+echo "Installing plugin $PLUGIN_ID for $IDEA_VERSION in $PLUGINS_DIR"
+cd "$PLUGINS_DIR" || exit
+
+LATEST=$(curl -s https://plugins.jetbrains.com/api/plugins/$PLUGIN_ID/updates \
+  | jq -r '[.[] | select( .version | startswith(env.IDEA_VERSION))][0].file')
+ARCHIVE_NAME=$(basename "$LATEST")
+curl "https://plugins.jetbrains.com/files/$LATEST" > "$ARCHIVE_NAME"
+unzip $ARCHIVE_NAME
+rm $ARCHIVE_NAME


### PR DESCRIPTION
The plug-ins can be set as a white-space separated build argument
`PLUGIN_IDS`. For example to build with a scala plug-in:
```
docker build --build-arg PLUGIN_IDS=1347 .
```