### PR TITLE
PHPStorm - Update openjdk to 21 and use debian bullseye // Update PHPStorm to 2023.1.2

### DIFF
--- a/phpstorm/Dockerfile
+++ b/phpstorm/Dockerfile
@@ -1,11 +1,8 @@
-FROM openjdk:21-jdk-bullseye
+FROM openjdk:21-jdk-slim-bullseye
 ARG IDEA_VERSION=PhpStorm-2023.1.2
 
-RUN        apt-get update
-RUN        apt-get install -y --no-install-recommends vim
-RUN        apt-get install -y --no-install-recommends wget
-RUN        apt-get install -y --no-install-recommends maven
-RUN        apt-get install -y --no-install-recommends groovy
+RUN        apt-get update && \
+           apt-get install -y --no-install-recommends curl wget maven groovy
 
 # Clean the APT cache to reduce the size of the container. This step is for
 # hygiene and can be omitted if needed.

--- a/phpstorm/Dockerfile
+++ b/phpstorm/Dockerfile
@@ -1,5 +1,5 @@
-FROM openjdk:8u151-jdk
-ARG IDEA_VERSION=PhpStorm-2021.1.3
+FROM openjdk:21-jdk-bullseye
+ARG IDEA_VERSION=PhpStorm-2023.1.2
 
 RUN        apt-get update
 RUN        apt-get install -y --no-install-recommends vim


### PR DESCRIPTION
Debian has archived the stretch packages and this is causing the images to fail during build. 
This updates the JDK and uses bullseye
It also updates PHPStorm to 2023.1.2